### PR TITLE
Add out-of-core FFT support and in-place operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ print(scaleinvariance.get_backend())  # 'torch' if available, else 'numpy'
 scaleinvariance.set_backend('numpy')  # Always use NumPy
 scaleinvariance.set_backend('torch')  # Use torch (raises error if not installed)
 
+# GPU acceleration (torch backend only)
+scaleinvariance.set_device('cuda')
+
+# Simulations larger than GPU memory: keep arrays in host RAM and stream
+# N-D FFTs through the GPU in bounded chunks (out-of-core mode). Maximum
+# simulation size is then limited by host RAM instead of VRAM.
+scaleinvariance.set_device('cpu')
+scaleinvariance.set_fft_device('cuda')
+
 # Configure threading (defaults to 90% CPU count)
 scaleinvariance.set_num_threads(8)
 ```

--- a/agent-skills/scaleinvariance/SKILL.md
+++ b/agent-skills/scaleinvariance/SKILL.md
@@ -533,6 +533,30 @@ All public functions return NumPy arrays regardless of backend. Internally,
 the torch backend keeps data as native tensors (on the active device) to
 avoid per-operation CPU<->GPU transfers.
 
+### Simulations larger than GPU memory (out-of-core FFTs)
+
+FIF peak memory is ~4x the simulation-domain buffer (and the domain is
+doubled along each non-periodic axis, so a fully non-periodic 2D output
+costs 4x its own element count again, 8x in 3D). When a simulation no
+longer fits in GPU VRAM, keep the arrays in host RAM and stream only the
+FFTs through the GPU:
+
+```python
+scaleinvariance.set_backend('torch')
+scaleinvariance.set_device('cpu')        # arrays live in host RAM
+scaleinvariance.set_fft_device('cuda')   # N-D FFTs stream through the GPU in chunks
+# optional chunk size: scaleinvariance.set_fft_device('cuda', chunk_bytes=2**30)
+scaleinvariance.set_fft_device(None)     # disable (back to direct FFTs)
+```
+
+Maximum size is then bounded by host RAM instead of VRAM (typically ~10x
+larger), at the cost of PCIe transfers per FFT pass. GPU memory use is a
+few times `chunk_bytes` (default 512 MB) regardless of simulation size;
+element-wise stages run on CPU in this mode. Only full N-D transforms
+(`ndim >= 2`) are chunked — 1D simulations are unaffected. Chunked FFTs
+are mathematically identical but not bit-identical to direct ones
+(differences at FFT round-off level).
+
 ### Overflow guards in FIF simulations
 
 `FIF_1D` and `FIF_ND` clip the internal log-flux to a precision-aware

--- a/scaleinvariance/__init__.py
+++ b/scaleinvariance/__init__.py
@@ -47,5 +47,7 @@ from .backend import (
     get_numerical_precision,
     set_device,
     get_device,
+    set_fft_device,
+    get_fft_device,
     to_numpy,
 )

--- a/scaleinvariance/backend.py
+++ b/scaleinvariance/backend.py
@@ -162,6 +162,85 @@ def get_device():
     return _device
 
 
+# FFT offload state: when set, large N-D FFTs are computed by streaming
+# axis-batched chunks through this device instead of transforming the whole
+# array at once on the array's own device.
+_fft_device = None
+_fft_device_obj = None
+_fft_chunk_bytes = 1 << 29  # 512 MB per streamed chunk
+
+
+def set_fft_device(device=None, chunk_bytes=None):
+    """Route N-D FFTs through a separate compute device in chunks.
+
+    This enables *out-of-core* FFTs: arrays stay resident on the main
+    device (typically CPU/host RAM, set via :func:`set_device`), and each
+    multi-dimensional FFT is decomposed into per-axis batched 1D FFTs that
+    are streamed through *device* (typically a GPU) one chunk at a time.
+    Peak memory on the FFT device is a few times ``chunk_bytes`` regardless
+    of array size, so the maximum simulation size is bounded by host RAM
+    rather than GPU VRAM — typically an order of magnitude larger — while
+    retaining most of the GPU's FFT throughput.
+
+    Typical use for simulations larger than GPU memory::
+
+        import scaleinvariance as si
+        si.set_backend('torch')
+        si.set_device('cpu')          # arrays live in host RAM
+        si.set_fft_device('cuda')     # FFTs stream through the GPU
+
+    Only ``backend='torch'`` is supported. Only full N-D transforms
+    (``ndim >= 2``, all axes) are chunked; 1D transforms and axis-subset
+    transforms run directly on the array's device as usual.
+
+    Chunked transforms are mathematically identical to direct ones but are
+    not bit-identical (per-axis transform order differs); expect
+    differences at the level of FFT round-off.
+
+    Parameters
+    ----------
+    device : str or None
+        Device to stream FFT chunks through (e.g. ``'cuda'``). ``None``
+        (default) disables offloading and restores direct FFTs.
+    chunk_bytes : int, optional
+        Approximate bytes per streamed chunk. Default 2**29 (512 MB).
+        The FFT device needs roughly 3-4x this much free memory.
+
+    Raises
+    ------
+    ImportError
+        If a device is requested but PyTorch is not installed.
+    RuntimeError
+        If CUDA is requested but not available.
+    """
+    global _fft_device, _fft_device_obj, _fft_chunk_bytes
+    if chunk_bytes is not None:
+        chunk_bytes = int(chunk_bytes)
+        if chunk_bytes <= 0:
+            raise ValueError(f"chunk_bytes must be positive; got {chunk_bytes}")
+        _fft_chunk_bytes = chunk_bytes
+    if device is None:
+        _fft_device = None
+        _fft_device_obj = None
+        return
+    if not _torch_available:
+        raise ImportError(
+            f"FFT device '{device}' requested but PyTorch is not installed. "
+            "Install with: pip install torch"
+        )
+    if 'cuda' in device and not torch.cuda.is_available():
+        raise RuntimeError(
+            f"FFT device '{device}' requested but CUDA is not available."
+        )
+    _fft_device = device
+    _fft_device_obj = torch.device(device)
+
+
+def get_fft_device():
+    """Get the FFT offload device string, or None if offloading is disabled."""
+    return _fft_device
+
+
 # ============================================================================
 # Dtype helpers
 # ============================================================================
@@ -337,16 +416,20 @@ def fftn(x, axes=None):
     """N-D FFT."""
     if _backend == 'numpy':
         return np.fft.fftn(x, axes=axes)
-    else:
-        return torch.fft.fftn(_to_torch(x, _active_complex_dtype_torch()), dim=axes)
+    x_t = _to_torch(x, _active_complex_dtype_torch())
+    if _fft_offload_active(x_t, axes):
+        return _chunked_cfftn(x_t, inverse=False)
+    return torch.fft.fftn(x_t, dim=axes)
 
 
 def ifftn(x, axes=None):
     """N-D inverse FFT."""
     if _backend == 'numpy':
         return np.fft.ifftn(x, axes=axes)
-    else:
-        return torch.fft.ifftn(_to_torch(x, _active_complex_dtype_torch()), dim=axes)
+    x_t = _to_torch(x, _active_complex_dtype_torch())
+    if _fft_offload_active(x_t, axes):
+        return _chunked_cfftn(x_t, inverse=True)
+    return torch.fft.ifftn(x_t, dim=axes)
 
 
 def rfft(x, axis=-1):
@@ -370,8 +453,10 @@ def rfftn(x, axes=None):
     """N-D real FFT (real input, last axis halved)."""
     if _backend == 'numpy':
         return np.fft.rfftn(x, axes=axes)
-    else:
-        return torch.fft.rfftn(_to_torch(x, _active_real_dtype_torch()), dim=axes)
+    x_t = _to_torch(x, _active_real_dtype_torch())
+    if _fft_offload_active(x_t, axes):
+        return _chunked_rfftn(x_t)
+    return torch.fft.rfftn(x_t, dim=axes)
 
 
 def irfft2(x, s):
@@ -382,14 +467,22 @@ def irfft2(x, s):
         return torch.fft.irfft2(_to_torch(x, _active_complex_dtype_torch()), s=s)
 
 
-def irfftn(x, s):
-    """N-D inverse real FFT."""
+def irfftn(x, s, overwrite_input=False):
+    """N-D inverse real FFT.
+
+    ``overwrite_input=True`` permits the chunked out-of-core path (active
+    when an FFT device is set) to reuse the input spectrum as scratch,
+    avoiding one full-size complex copy. Only pass it for spectra you
+    discard afterwards. Ignored on the numpy backend and on direct
+    transforms.
+    """
     axes = list(range(-len(s), 0))
     if _backend == 'numpy':
         return np.fft.irfftn(x, s=s, axes=axes)
-    else:
-        return torch.fft.irfftn(_to_torch(x, _active_complex_dtype_torch()),
-                                s=s, dim=axes)
+    x_t = _to_torch(x, _active_complex_dtype_torch())
+    if _fft_device_obj is not None and x_t.ndim >= 2 and len(s) == x_t.ndim:
+        return _chunked_irfftn(x_t, s, overwrite_input=overwrite_input)
+    return torch.fft.irfftn(x_t, s=s, dim=axes)
 
 
 def ifftshift(x, axes=None):
@@ -398,6 +491,108 @@ def ifftshift(x, axes=None):
         return np.fft.ifftshift(x, axes=axes)
     else:
         return torch.fft.ifftshift(_to_torch(x), dim=axes)
+
+
+# ----------------------------------------------------------------------------
+# Chunked / out-of-core FFT engine (torch only; see set_fft_device)
+# ----------------------------------------------------------------------------
+# N-D transforms decompose into per-axis batched 1D transforms. Each stage
+# streams chunks of bounded size (_fft_chunk_bytes) through the FFT device,
+# so device memory stays O(chunk) while the arrays themselves stay on the
+# main device (typically host RAM). Chunked results are mathematically
+# identical to direct transforms but differ at FFT round-off level because
+# the per-axis evaluation order differs.
+
+def _fft_offload_active(x_t, axes):
+    """Chunk a full N-D transform of a torch tensor when offload is enabled."""
+    return _fft_device_obj is not None and axes is None and x_t.ndim >= 2
+
+
+def _slab_slices(n, step):
+    for start in range(0, n, step):
+        yield slice(start, min(start + step, n))
+
+
+def _chunk_rows(row_bytes):
+    # builtins.max — this module shadows `max` with its own reduction.
+    rows = _fft_chunk_bytes // row_bytes if row_bytes > 0 else 1
+    return rows if rows > 0 else 1
+
+
+def _chunked_fft_axis_(z, ax, inverse):
+    """In-place chunked 1D (i)FFT along axis ``ax`` of complex tensor ``z``,
+    streamed through the FFT device. Chunks along a different axis so each
+    transferred block contains complete transform lines."""
+    nd = z.ndim
+    chunk_ax = nd - 1 if ax != nd - 1 else nd - 2
+    n_chunk = z.shape[chunk_ax]
+    per_unit = (z.numel() // n_chunk) * z.element_size()
+    step = _chunk_rows(per_unit)
+    fn = torch.fft.ifft if inverse else torch.fft.fft
+    index = [slice(None)] * nd
+    for sl in _slab_slices(n_chunk, step):
+        index[chunk_ax] = sl
+        idx = tuple(index)
+        g = z[idx].contiguous().to(_fft_device_obj)
+        z[idx] = fn(g, dim=ax).to(z.device)
+
+
+def _chunked_rfftn(x):
+    """Out-of-core rfftn over all axes of a real tensor (ndim >= 2)."""
+    x = x.contiguous()
+    shape = tuple(x.shape)
+    out_shape = shape[:-1] + (shape[-1] // 2 + 1,)
+    out = torch.empty(out_shape, dtype=_active_complex_dtype_torch(),
+                      device=x.device)
+    # Stage 1: real FFT along the contiguous last axis, slab over rows.
+    x2 = x.reshape(-1, shape[-1])
+    o2 = out.reshape(-1, out_shape[-1])
+    step = _chunk_rows(shape[-1] * x.element_size())
+    for sl in _slab_slices(x2.shape[0], step):
+        g = x2[sl].to(_fft_device_obj)
+        o2[sl] = torch.fft.rfft(g, dim=-1).to(x.device)
+    # Remaining axes: complex FFTs over the half-spectrum.
+    for ax in range(x.ndim - 1):
+        _chunked_fft_axis_(out, ax, inverse=False)
+    return out
+
+
+def _chunked_irfftn(x, s, overwrite_input=False):
+    """Out-of-core irfftn (all axes) of complex spectrum ``x`` to real shape ``s``."""
+    s = tuple(int(v) for v in s)
+    expected = s[:-1] + (s[-1] // 2 + 1,)
+    if tuple(x.shape) != expected:
+        raise ValueError(
+            f"Chunked irfftn requires spectrum shape {expected} for output "
+            f"shape {s}; got {tuple(x.shape)}. Call set_fft_device(None) for "
+            "cropped/padded inverse transforms."
+        )
+    if overwrite_input and x.is_contiguous():
+        work = x
+    elif x.is_contiguous():
+        work = x.clone()
+    else:
+        work = x.contiguous()
+    for ax in range(x.ndim - 1):
+        _chunked_fft_axis_(work, ax, inverse=True)
+    out = torch.empty(s, dtype=_active_real_dtype_torch(), device=x.device)
+    w2 = work.reshape(-1, work.shape[-1])
+    o2 = out.reshape(-1, s[-1])
+    step = _chunk_rows(work.shape[-1] * work.element_size())
+    for sl in _slab_slices(w2.shape[0], step):
+        g = w2[sl].to(_fft_device_obj)
+        o2[sl] = torch.fft.irfft(g, n=s[-1], dim=-1).to(x.device)
+    return out
+
+
+def _chunked_cfftn(x, inverse):
+    """Out-of-core complex fftn/ifftn over all axes (ndim >= 2)."""
+    work = x.contiguous()
+    if work is x:
+        work = x.clone()
+    for ax in range(x.ndim):
+        _chunked_fft_axis_(work, ax, inverse)
+    return work
 
 
 # ============================================================================
@@ -453,10 +648,15 @@ def exponential(scale, size=None):
     else:
         if size is None:
             size = 1
-        rate = torch.tensor(1.0 / scale, dtype=_active_real_dtype_torch(),
-                            device=_device_obj)
-        dist = torch.distributions.Exponential(rate)
-        return dist.sample(size if isinstance(size, tuple) else (size,))
+        shape = size if isinstance(size, tuple) else (size,)
+        # Draw via Tensor.exponential_ directly. Exponential(rate).sample()
+        # is `empty(shape).exponential_() / rate`, which allocates two extra
+        # full-size buffers (the pre-division draw and the division result)
+        # and is bit-identical to this for scale=1 since the underlying RNG
+        # transform is the same call.
+        out = torch.empty(shape, dtype=_active_real_dtype_torch(),
+                          device=_device_obj)
+        return out.exponential_(lambd=1.0 / scale)
 
 
 # ============================================================================
@@ -670,6 +870,123 @@ def pad(x, before, after, axis=-1, value=0):
         pad_list[idx] = before
         pad_list[idx + 1] = after
         return F.pad(x_torch, pad_list, mode='constant', value=value)
+
+
+# ============================================================================
+# In-place Operations
+# ============================================================================
+# These mutate (and return) their first argument. They exist so the
+# simulation pipeline can bound its peak memory: every call below performs
+# exactly the same arithmetic as the out-of-place equivalent (bit-identical
+# results), just without allocating a new full-size buffer. Only pass
+# arrays you own — never user-supplied input.
+
+def imul(x, y):
+    """In-place ``x *= y``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.multiply(x, y, out=x)
+    else:
+        x.mul_(y)
+    return x
+
+
+def iadd(x, y):
+    """In-place ``x += y``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.add(x, y, out=x)
+    else:
+        x.add_(y)
+    return x
+
+
+def isub(x, y):
+    """In-place ``x -= y``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.subtract(x, y, out=x)
+    else:
+        x.sub_(y)
+    return x
+
+
+def idiv(x, y):
+    """In-place ``x /= y``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.divide(x, y, out=x)
+    else:
+        x.div_(y)
+    return x
+
+
+def ipow(x, p):
+    """In-place ``x **= p``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.power(x, p, out=x)
+    else:
+        x.pow_(p)
+    return x
+
+
+def ineg(x):
+    """In-place ``x = -x``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.negative(x, out=x)
+    else:
+        x.neg_()
+    return x
+
+
+def iexp(x):
+    """In-place ``x = exp(x)``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.exp(x, out=x)
+    else:
+        x.exp_()
+    return x
+
+
+def icos(x):
+    """In-place ``x = cos(x)``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.cos(x, out=x)
+    else:
+        x.cos_()
+    return x
+
+
+def isin(x):
+    """In-place ``x = sin(x)``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.sin(x, out=x)
+    else:
+        x.sin_()
+    return x
+
+
+def isqrt(x):
+    """In-place ``x = sqrt(x)``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.sqrt(x, out=x)
+    else:
+        x.sqrt_()
+    return x
+
+
+def iclip(x, x_min, x_max):
+    """In-place clip. ``x_min`` or ``x_max`` may be ``None``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.clip(x, x_min, x_max, out=x)
+    else:
+        x.clamp_(min=x_min, max=x_max)
+    return x
+
+
+def imaximum(x, scalar):
+    """In-place element-wise ``x = maximum(x, scalar)``. Returns ``x``."""
+    if _backend == 'numpy':
+        np.maximum(x, scalar, out=x)
+    else:
+        x.clamp_(min=scalar)
+    return x
 
 
 # ============================================================================

--- a/scaleinvariance/simulation/FIF.py
+++ b/scaleinvariance/simulation/FIF.py
@@ -8,20 +8,30 @@ from .kernels import (
     create_kernel_spectral_odd,
     _normalize_axis_flag,
 )
-from .fractional_integration import fractional_integral_spectral
+from .fractional_integration import (
+    _build_riesz_kernel,
+    _guard_single_kernel_overflow,
+)
 
-def _clip_and_exp_flux(scaled, caller_name):
+def _clip_and_exp_flux(scaled, caller_name, in_place=False):
     """Clip the log-flux to safe exponent range for the active precision,
     warn if saturation occurred, and return ``exp(scaled)``.
 
     Prevents unbounded `exp(scaled)` from producing ``inf`` for extreme
     cascade amplitudes, and lets users know their simulation hit the
     ceiling instead of silently saturating.
+
+    With ``in_place=True`` the clip and exp mutate ``scaled`` (which must
+    be a native array of the active backend) instead of allocating new
+    full-size buffers. Used by the FIF pipeline on arrays it owns.
     """
     lo, hi = B.exp_clip_limits()
     saturated = int(B.sum(scaled < lo)) + int(B.sum(scaled > hi))
-    scaled_clipped = B.clip(scaled, lo, hi)
-    flux = B.exp(scaled_clipped)
+    if in_place:
+        flux = B.iexp(B.iclip(scaled, lo, hi))
+    else:
+        scaled_clipped = B.clip(scaled, lo, hi)
+        flux = B.exp(scaled_clipped)
     if saturated > 0:
         warnings.warn(
             f"{caller_name}: {saturated} flux samples clipped at exp limits "
@@ -34,9 +44,23 @@ def _clip_and_exp_flux(scaled, caller_name):
 
 
 def _extremal_levy_core(alpha, size=1):
-    """Core extremal Lévy generation. Returns native backend type (tensor or ndarray)."""
-    phi = (B.rand(size) - 0.5) * B.pi
-    R = B.exponential(scale=1.0, size=size)
+    """Core extremal Lévy generation. Returns native backend type (tensor or ndarray).
+
+    Computes, with ``t = alpha * (phi - phi0)``::
+
+        sample = sign(alpha - 1) * sin(t)
+                 * (clip(cos(phi)) * |alpha - 1|) ** (-1/alpha)
+                 * (clip(cos(phi - t)) / clip(R)) ** ((1 - alpha) / alpha)
+
+    The implementation below performs exactly these operations (bit-identical
+    to the straightforward expression) but uses in-place backend ops so the
+    peak allocation is three full-size buffers instead of ~seven. ``R`` is
+    drawn just before its single use; the RNG call order (uniform draw, then
+    exponential draw) is unchanged, so seeded streams are unaffected.
+    """
+    phi = B.rand(size)
+    B.isub(phi, 0.5)
+    B.imul(phi, B.pi)
     eps = B.eps()
 
     # Keep all alpha-dependent constants as Python floats — passing them
@@ -54,17 +78,33 @@ def _extremal_levy_core(alpha, size=1):
 
     # phi ∈ [-pi/2, pi/2] so cos(phi) ≥ 0; clip protects the negative-power
     # below against underflow (and floating-point drift at the endpoints).
-    cos_phi = B.clip(B.cos(phi), eps, None)
-    denom = B.clip(B.cos(phi - alpha_t * (phi - phi0)), eps, None)
-    R = B.clip(R, eps, None)
+    cos_phi = B.cos(phi)
+    B.iclip(cos_phi, eps, None)
 
-    sample = (
-        sign_alpha_minus_1
-        * B.sin(alpha_t * (phi - phi0))
-        * (cos_phi * abs_alpha1) ** inv_alpha_neg
-        * (denom / R) ** pow_denom_R
-    )
-    del phi, cos_phi, denom, R
+    t = phi - phi0
+    B.imul(t, alpha_t)              # t = alpha * (phi - phi0)
+
+    # denom = clip(cos(phi - t)); reuses phi's buffer.
+    denom = B.isub(phi, t)
+    B.icos(denom)
+    B.iclip(denom, eps, None)
+    del phi
+
+    # Assemble the sample in t's buffer: sign * sin(t) * cos-power * R-power.
+    sample = B.isin(t)
+    if sign_alpha_minus_1 < 0:
+        B.ineg(sample)
+    B.imul(cos_phi, abs_alpha1)
+    B.ipow(cos_phi, inv_alpha_neg)
+    B.imul(sample, cos_phi)
+    del cos_phi
+    R = B.exponential(scale=1.0, size=size)
+    B.iclip(R, eps, None)
+    B.idiv(denom, R)
+    del R
+    B.ipow(denom, pow_denom_R)
+    B.imul(sample, denom)
+    del denom, t
     return sample
 
 
@@ -130,7 +170,8 @@ def periodic_convolve(signal, kernel, kernel_is_fourier=False):
                 "Signal and kernel must have the same length for periodic convolution."
             )
         fft_signal = B.fft(signal)
-        return B.real(B.ifft(fft_signal * fft_kernel))
+        B.imul(fft_signal, fft_kernel)
+        return B.real(B.ifft(fft_signal))
 
     # Real-kernel path: use rfft/irfft.
     if kernel_is_fourier:
@@ -156,7 +197,8 @@ def periodic_convolve(signal, kernel, kernel_is_fourier=False):
         rfft_kernel = B.rfft(B.ifftshift(kernel_arr))
 
     rfft_signal = B.rfft(signal)
-    return B.irfft(rfft_signal * rfft_kernel, n=n)
+    B.imul(rfft_signal, rfft_kernel)
+    return B.irfft(rfft_signal, n=n)
 
 
 def periodic_convolve_nd(signal, kernel, kernel_is_fourier=False):
@@ -193,7 +235,8 @@ def periodic_convolve_nd(signal, kernel, kernel_is_fourier=False):
                 "Signal and kernel must have the same shape for periodic convolution."
             )
         fft_signal = B.fftn(signal)
-        return B.real(B.ifftn(fft_signal * fft_kernel))
+        B.imul(fft_signal, fft_kernel)
+        return B.real(B.ifftn(fft_signal))
 
     # Real-kernel path: rfftn/irfftn.
     expected_half_shape = shape[:-1] + (shape[-1] // 2 + 1,)
@@ -220,7 +263,8 @@ def periodic_convolve_nd(signal, kernel, kernel_is_fourier=False):
         rfftn_kernel = B.rfftn(B.ifftshift(kernel_arr))
 
     rfftn_signal = B.rfftn(signal)
-    return B.irfftn(rfftn_signal * rfftn_kernel, s=shape)
+    B.imul(rfftn_signal, rfftn_kernel)
+    return B.irfftn(rfftn_signal, s=shape, overwrite_input=True)
 
 
 def _warn_if_naive_kernel_selected(kernel_construction_method_flux, kernel_construction_method_observable):
@@ -484,17 +528,11 @@ def FIF_1D(size, alpha, C1, H, levy_noise=None, causal=False, outer_scale=None,
 
     _warn_if_naive_kernel_selected(kernel_construction_method_flux, kernel_construction_method_observable)
 
-    if levy_noise is None:
-        noise = _extremal_levy_core(alpha, size=size)
-    else:
+    if levy_noise is not None:
         levy_noise_arr = B.asarray(levy_noise)
         if B.numel(levy_noise_arr) != output_size:
             raise ValueError("Provided levy_noise must match the specified size.")
-        # if aperiodic is requested, need to pad noise with more noise
-        if not periodic:
-            noise = B.concatenate([levy_noise_arr, _extremal_levy_core(alpha, size=output_size)])
-        else:
-            noise = levy_noise_arr
+
     if outer_scale is None and outer_scale_width_factor != 2.0:
         warnings.warn(
             "outer_scale_width_factor has no effect when outer_scale is None "
@@ -522,8 +560,30 @@ def FIF_1D(size, alpha, C1, H, levy_noise=None, causal=False, outer_scale=None,
         raise ValueError(f"Unknown kernel_construction_method_flux: {kernel_construction_method_flux}. "
                          "Supported: 'LS2010', 'naive'.")
 
-    integrated = periodic_convolve(noise, kernel1)
-    del noise, kernel1  # Clean memory
+    # Move the kernel to Fourier space before generating the noise so the
+    # real-space kernel and the noise never coexist (bounds peak memory).
+    kernel1_shifted = B.ifftshift(kernel1)
+    del kernel1
+    kernel1_fft = B.rfft(kernel1_shifted)
+    del kernel1_shifted
+
+    if levy_noise is None:
+        noise = _extremal_levy_core(alpha, size=size)
+    elif not periodic:
+        # if aperiodic is requested, need to pad noise with more noise
+        noise = B.concatenate([levy_noise_arr, _extremal_levy_core(alpha, size=output_size)])
+    else:
+        noise = levy_noise_arr
+
+    # Periodic convolution with the flux kernel (same arithmetic as
+    # periodic_convolve), spelled out so each full-size buffer is released
+    # as soon as possible.
+    spectrum = B.rfft(noise)
+    del noise
+    B.imul(spectrum, kernel1_fft)
+    del kernel1_fft
+    integrated = B.irfft(spectrum, n=size)
+    del spectrum
 
     # If causal, adjust for the fact that half the kernel is being deleted
     if causal:
@@ -531,11 +591,9 @@ def FIF_1D(size, alpha, C1, H, levy_noise=None, causal=False, outer_scale=None,
     else:
         causality_factor = 1.0
 
-
-    scaled = integrated * ((causality_factor * C1) ** (1/alpha))
+    B.imul(integrated, (causality_factor * C1) ** (1/alpha))
+    flux = _clip_and_exp_flux(integrated, "FIF_1D", in_place=True)
     del integrated
-    flux = _clip_and_exp_flux(scaled, "FIF_1D")
-    del scaled
 
     if H == 0:
         # Integrator is identity (H=0 after any remap). Skip the observable
@@ -569,11 +627,21 @@ def FIF_1D(size, alpha, C1, H, levy_noise=None, causal=False, outer_scale=None,
         if causal:
             raise ValueError("Spectral observable kernels do not support causal mode. "
                              "Use kernel_construction_method_observable='LS2010' with causal=True.")
-        observable = fractional_integral_spectral(
-            flux, H, outer_scale=outer_scale,
-            odd_axes=odd_tuple_1d if has_odd else None,
-        )
+        # Same arithmetic as fractional_integral_spectral(flux, H, ...),
+        # spelled out so the flux buffer is released right after its
+        # forward FFT instead of staying alive for the whole call.
+        if outer_scale is not None and outer_scale <= 0:
+            raise ValueError(f"outer_scale must be positive; got {outer_scale}.")
+        obs_outer_scale = size if outer_scale is None else outer_scale
+        _guard_single_kernel_overflow(obs_outer_scale, H, 1)
+        riesz_kernel = _build_riesz_kernel((size,), H, obs_outer_scale,
+                                           odd_tuple_1d)
+        spectrum = B.rfft(flux)
         del flux
+        B.imul(spectrum, riesz_kernel)
+        del riesz_kernel
+        observable = B.irfft(spectrum, n=size)
+        del spectrum
     else:
         if has_odd:
             # The real-space LS2010 kernel mixes a power-law part with a
@@ -602,8 +670,18 @@ def FIF_1D(size, alpha, C1, H, levy_noise=None, causal=False, outer_scale=None,
         else:
             raise ValueError(f"Unknown kernel_construction_method_observable: {kernel_construction_method_observable}")
 
-        observable = periodic_convolve(flux, kernel2)
-        del flux, kernel2
+        # Inline periodic convolution with eager buffer release (same
+        # arithmetic as periodic_convolve).
+        kernel2_shifted = B.ifftshift(kernel2)
+        del kernel2
+        kernel2_fft = B.rfft(kernel2_shifted)
+        del kernel2_shifted
+        spectrum = B.rfft(flux)
+        del flux
+        B.imul(spectrum, kernel2_fft)
+        del kernel2_fft
+        observable = B.irfft(spectrum, n=size)
+        del spectrum
 
     if not periodic:
         observable = observable[:size//2]     # eliminate periodicity by removing the part corresponding to the appended noise
@@ -954,23 +1032,15 @@ def FIF_ND(size, alpha, C1, H, levy_noise=None, outer_scale=None, outer_scale_wi
             "For non-spectral observable kernels, H must be between 0 and 1."
         )
 
-    # Generate or validate Lévy noise
-    if levy_noise is None:
-        total_size = np.prod(sim_size)
-        noise = _extremal_levy_core(alpha, size=total_size).reshape(sim_size)
-    else:
+    # Validate provided Lévy noise before doing any heavy work
+    if levy_noise is not None:
         levy_tensor = B.asarray(levy_noise)
         if all(periodic_tuple):
             if levy_tensor.shape != sim_size:
                 raise ValueError("Provided levy_noise must match the specified size.")
-            noise = levy_tensor
         else:
             if levy_tensor.shape != output_size:
                 raise ValueError("Provided levy_noise must match the specified size.")
-            total_size = np.prod(sim_size)
-            noise = _extremal_levy_core(alpha, size=total_size).reshape(sim_size)
-            # Insert provided noise at the beginning
-            noise[tuple(slice(s) for s in output_size)] = levy_tensor
 
     # Create flux kernel (kernel 1)
     # Calculate exponent and normalization parameters for N-D flux kernel
@@ -988,18 +1058,41 @@ def FIF_ND(size, alpha, C1, H, levy_noise=None, outer_scale=None, outer_scale_wi
         raise ValueError(f"Unknown kernel_construction_method_flux for N-D: {kernel_construction_method_flux}. "
                          "Supported: 'LS2010'.")
 
-    # Perform first convolution
-    integrated = periodic_convolve_nd(noise, kernel1)
-    del noise, kernel1
+    # Move the kernel to Fourier space before generating the noise so the
+    # real-space kernel and the noise never coexist (bounds peak memory).
+    kernel1_shifted = B.ifftshift(kernel1)
+    del kernel1
+    kernel1_fft = B.rfftn(kernel1_shifted)
+    del kernel1_shifted
+
+    # Generate or place Lévy noise
+    if levy_noise is None:
+        total_size = np.prod(sim_size)
+        noise = _extremal_levy_core(alpha, size=total_size).reshape(sim_size)
+    elif all(periodic_tuple):
+        noise = levy_tensor
+    else:
+        total_size = np.prod(sim_size)
+        noise = _extremal_levy_core(alpha, size=total_size).reshape(sim_size)
+        # Insert provided noise at the beginning
+        noise[tuple(slice(s) for s in output_size)] = levy_tensor
+
+    # First convolution (same arithmetic as periodic_convolve_nd), spelled
+    # out so each full-size buffer is released as soon as possible.
+    spectrum = B.rfftn(noise)
+    del noise
+    B.imul(spectrum, kernel1_fft)
+    del kernel1_fft
+    integrated = B.irfftn(spectrum, s=sim_size, overwrite_input=True)
+    del spectrum
 
     # Causality compensates variance: with k causal axes the kernel keeps a
     # fraction 1/2^k of its mass, so the log-flux variance drops by 1/2^k.
     # Scale up by 2^k inside the C1 factor to restore the target variance.
     causality_factor = 2.0 ** n_causal_axes
-    scaled = integrated * ((causality_factor * C1) ** (1/alpha))
+    B.imul(integrated, (causality_factor * C1) ** (1/alpha))
+    flux = _clip_and_exp_flux(integrated, "FIF_ND", in_place=True)
     del integrated
-    flux = _clip_and_exp_flux(scaled, "FIF_ND")
-    del scaled
 
     if H == 0:
         if has_odd:
@@ -1025,11 +1118,21 @@ def FIF_ND(size, alpha, C1, H, levy_noise=None, outer_scale=None, outer_scale_wi
                 "Spectral observable kernels do not support causal mode. "
                 "Use kernel_construction_method_observable='LS2010' with causal=True."
             )
-        observable = fractional_integral_spectral(
-            flux, H, outer_scale=outer_scale,
-            odd_axes=odd_tuple if has_odd else None,
-        )
+        # Same arithmetic as fractional_integral_spectral(flux, H, ...),
+        # spelled out so the flux buffer is released right after its
+        # forward FFT instead of staying alive for the whole call.
+        if outer_scale is not None and outer_scale <= 0:
+            raise ValueError(f"outer_scale must be positive; got {outer_scale}.")
+        obs_outer_scale = max(sim_size) if outer_scale is None else outer_scale
+        _guard_single_kernel_overflow(obs_outer_scale, H, ndim)
+        riesz_kernel = _build_riesz_kernel(sim_size, H, obs_outer_scale,
+                                           odd_tuple)
+        spectrum = B.rfftn(flux)
         del flux
+        B.imul(spectrum, riesz_kernel)
+        del riesz_kernel
+        observable = B.irfftn(spectrum, s=sim_size, overwrite_input=True)
+        del spectrum
     elif kernel_construction_method_observable == 'LS2010':
         if has_odd:
             # See FIF_1D for the same restriction. Real-space sign-flipping
@@ -1047,8 +1150,18 @@ def FIF_ND(size, alpha, C1, H, levy_noise=None, outer_scale=None, outer_scale_wi
                                       causal=causal_tuple, outer_scale=outer_scale,
                                       outer_scale_width_factor=outer_scale_width_factor,
                                       final_power=None, scale_metric=scale_metric)
-        observable = periodic_convolve_nd(flux, kernel2)
-        del flux, kernel2
+        # Inline periodic convolution with eager buffer release (same
+        # arithmetic as periodic_convolve_nd).
+        kernel2_shifted = B.ifftshift(kernel2)
+        del kernel2
+        kernel2_fft = B.rfftn(kernel2_shifted)
+        del kernel2_shifted
+        spectrum = B.rfftn(flux)
+        del flux
+        B.imul(spectrum, kernel2_fft)
+        del kernel2_fft
+        observable = B.irfftn(spectrum, s=sim_size, overwrite_input=True)
+        del spectrum
     else:
         raise ValueError(f"Unknown kernel_construction_method_observable for N-D: {kernel_construction_method_observable}")
 

--- a/scaleinvariance/simulation/fractional_integration.py
+++ b/scaleinvariance/simulation/fractional_integration.py
@@ -24,7 +24,7 @@ def _isotropic_rfft_frequencies(shape):
         broadcast_shape[axis_idx] = axis.shape[0]
         term = axis.reshape(broadcast_shape) ** 2
         freqs_squared = term if freqs_squared is None else freqs_squared + term
-    return B.sqrt(freqs_squared)
+    return B.isqrt(freqs_squared)
 
 
 def _pow_or_inf(base, exp):
@@ -149,6 +149,67 @@ def _zero_odd_axis_nyquist(kernel, shape, odd_tuple):
         kernel[tuple(slicer)] = 0
 
 
+def _build_riesz_kernel(shape, H, outer_scale, odd_tuple):
+    """Build the rfftn-packed Fourier kernel used by
+    :func:`fractional_integral_spectral`: ``|f|^(-H)`` with low-frequency
+    regularization at ``1/outer_scale``, DC handling, and (optionally) the
+    odd-axes phase factor ``i^k · Π sign(f_j)``.
+
+    Returns a real array for the even path (and for an even number of odd
+    axes), complex for an odd number of odd axes. ``outer_scale`` must
+    already be resolved (not None) and the overflow guard already checked.
+    """
+    ndim = len(shape)
+    has_odd = any(odd_tuple)
+    rfft_shape = shape[:-1] + (shape[-1] // 2 + 1,)
+    freqs = _isotropic_rfft_frequencies(shape)
+    min_freq = 1.0 / float(outer_scale)
+    B.imaximum(freqs, min_freq)
+
+    magnitude = B.ipow(freqs, -H)
+    del freqs
+
+    if magnitude.shape != rfft_shape:
+        magnitude = magnitude + B.zeros(rfft_shape, dtype=magnitude.dtype)
+
+    if not has_odd:
+        # Standard (even) path: fill DC with nearest non-DC value to avoid a
+        # spectral notch.
+        kernel = magnitude
+        dc_index = (0,) * ndim
+        if B.numel(kernel) == 1:
+            kernel[dc_index] = 1.0
+        else:
+            neighbor_index = (1,) + (0,) * (ndim - 1)
+            kernel[dc_index] = kernel[neighbor_index]
+    else:
+        # Odd path: assemble K = i^k · Π sign(f_j) · |f|^(-H)
+        sign_product = _build_odd_phase_factor(shape, odd_tuple)
+        k_odd = sum(odd_tuple)
+        # i^k splits into a real sign (for even k) and a purely imaginary
+        # factor (for odd k). For k mod 4 = 0: +1; 1: +i; 2: -1; 3: -i.
+        phase_sign = 1.0 if (k_odd // 2) % 2 == 0 else -1.0
+        signed_magnitude = B.imul(magnitude, sign_product)
+        if phase_sign < 0:
+            B.ineg(signed_magnitude)
+        del magnitude, sign_product
+
+        if k_odd % 2 == 0:
+            kernel = signed_magnitude
+        else:
+            # Purely imaginary kernel: store in a complex array's imag part.
+            complex_dtype = B._active_complex_dtype_np()
+            kernel = B.zeros(signed_magnitude.shape, dtype=complex_dtype)
+            kernel.imag[:] = signed_magnitude
+            del signed_magnitude
+
+        # Nyquist along each odd even-sized axis must be zero. DC is already
+        # zero because sign(0) = 0.
+        _zero_odd_axis_nyquist(kernel, shape, odd_tuple)
+
+    return kernel
+
+
 def fractional_integral_spectral(signal, H, outer_scale=None, odd_axes=None):
     """
     Apply an acausal spectral fractional integral of order ``H`` to a real signal.
@@ -238,54 +299,12 @@ def fractional_integral_spectral(signal, H, outer_scale=None, odd_axes=None):
 
     _guard_single_kernel_overflow(outer_scale, H, ndim)
 
-    rfft_shape = shape[:-1] + (shape[-1] // 2 + 1,)
-    freqs = _isotropic_rfft_frequencies(shape)
-    min_freq = 1.0 / float(outer_scale)
-    freqs_reg = B.maximum(freqs, min_freq)
-    del freqs
+    kernel = _build_riesz_kernel(shape, H, outer_scale, odd_tuple)
 
-    magnitude = freqs_reg ** (-H)
-    del freqs_reg
-
-    if magnitude.shape != rfft_shape:
-        magnitude = magnitude + B.zeros(rfft_shape, dtype=magnitude.dtype)
-
-    if not has_odd:
-        # Standard (even) path: fill DC with nearest non-DC value to avoid a
-        # spectral notch.
-        kernel = magnitude
-        dc_index = (0,) * ndim
-        if B.numel(kernel) == 1:
-            kernel[dc_index] = 1.0
-        else:
-            neighbor_index = (1,) + (0,) * (ndim - 1)
-            kernel[dc_index] = kernel[neighbor_index]
-    else:
-        # Odd path: assemble K = i^k · Π sign(f_j) · |f|^(-H)
-        sign_product = _build_odd_phase_factor(shape, odd_tuple)
-        k_odd = sum(odd_tuple)
-        # i^k splits into a real sign (for even k) and a purely imaginary
-        # factor (for odd k). For k mod 4 = 0: +1; 1: +i; 2: -1; 3: -i.
-        phase_sign = 1.0 if (k_odd // 2) % 2 == 0 else -1.0
-        signed_magnitude = phase_sign * sign_product * magnitude
-        del magnitude, sign_product
-
-        if k_odd % 2 == 0:
-            kernel = signed_magnitude
-        else:
-            # Purely imaginary kernel: store in a complex array's imag part.
-            complex_dtype = B._active_complex_dtype_np()
-            kernel = B.zeros(signed_magnitude.shape, dtype=complex_dtype)
-            kernel.imag[:] = signed_magnitude
-            del signed_magnitude
-
-        # Nyquist along each odd even-sized axis must be zero. DC is already
-        # zero because sign(0) = 0.
-        _zero_odd_axis_nyquist(kernel, shape, odd_tuple)
-
-    spectrum = B.rfftn(signal) * kernel
+    spectrum = B.rfftn(signal)
+    B.imul(spectrum, kernel)
     del kernel
-    result = B.irfftn(spectrum, s=shape)
+    result = B.irfftn(spectrum, s=shape, overwrite_input=True)
     del spectrum
     return result
 
@@ -378,10 +397,9 @@ def broken_fractional_integral_spectral(
     )
 
     rfft_shape = shape[:-1] + (shape[-1] // 2 + 1,)
-    freqs = _isotropic_rfft_frequencies(shape)
+    freqs_reg = _isotropic_rfft_frequencies(shape)
     min_freq = 1.0 / float(outer_scale)
-    freqs_reg = B.maximum(freqs, min_freq)
-    del freqs
+    B.imaximum(freqs_reg, min_freq)
 
     k_t = 1.0 / float(transition_wavelength)
     small_scale_prefactor = k_t ** (H_small_scale - H_large_scale)
@@ -402,8 +420,9 @@ def broken_fractional_integral_spectral(
         neighbor_index = (1,) + (0,) * (ndim - 1)
         kernel[dc_index] = kernel[neighbor_index]
 
-    spectrum = B.rfftn(signal) * kernel
+    spectrum = B.rfftn(signal)
+    B.imul(spectrum, kernel)
     del kernel
-    result = B.irfftn(spectrum, s=shape)
+    result = B.irfftn(spectrum, s=shape, overwrite_input=True)
     del spectrum
     return result

--- a/scaleinvariance/simulation/kernels.py
+++ b/scaleinvariance/simulation/kernels.py
@@ -46,24 +46,26 @@ def _apply_outer_scale(kernel, distance, outer_scale, width_factor=2.0):
     ndarray
         Kernel with outer scale applied
     """
+    # NOTE: ``distance`` is consumed (mutated in place) — callers pass a
+    # temporary. The in-place chain below performs exactly the arithmetic of
+    # the old expression `kernel * 0.5*(1+cos(pi*clip((d-lo)/w, 0, 1)))`,
+    # without allocating window/normalized-distance buffers.
     distance = B.asarray(distance)
 
     # Transition region centered at outer_scale with width = outer_scale * width_factor
     transition_width = outer_scale * width_factor
     lower_edge = outer_scale - transition_width / 2.0
-    upper_edge = outer_scale + transition_width / 2.0
 
-    # Compute normalized distance: 0 at lower_edge, 1 at upper_edge
-    # Clamp to [0, 1] so values below lower_edge → 0, above upper_edge → 1
-    normalized_dist = B.clip((distance - lower_edge) / transition_width, 0.0, 1.0)
+    window = distance
+    B.isub(window, lower_edge)
+    B.idiv(window, transition_width)
+    B.iclip(window, 0.0, 1.0)
+    B.imul(window, B.pi)
+    B.icos(window)
+    B.iadd(window, 1.0)
+    B.imul(window, 0.5)
 
-    # Hanning window: 1 when normalized_dist=0, 0 when normalized_dist=1
-    window = 0.5 * (1.0 + B.cos(B.pi * normalized_dist))
-    del normalized_dist
-
-    result = kernel * window
-    del window
-    return result
+    return B.imul(kernel, window)
 
 # LS 2010 kernels
 
@@ -111,36 +113,46 @@ def _apply_LS2010_correction(distance, exponent, norm_ratio_exponent, final_powe
     cutoff_length2 = cutoff_length / ratio
 
     # Base singularity kernel (kept live; everything else below is temporary).
+    # All in-place chains below reproduce the previous out-of-place
+    # expressions operation-for-operation (bit-identical results) while
+    # holding at most two full-volume temporaries alongside base_kernel.
     base_kernel = distance ** exponent
 
-    # First normalization constant — use exp cutoff then drop the smoothed
-    # copy immediately so we never hold two full-volume copies at peak.
-    exp_cutoff1 = B.exp(B.clip(-(distance / cutoff_length) ** 4, -200, 0))
-    smoothed = base_kernel * exp_cutoff1
-    del exp_cutoff1
-    norm_constant1 = B.sum(smoothed)
-    del smoothed
+    def _smoothed_sum(cutoff):
+        # sum(base_kernel * exp(clip(-(distance/cutoff)**4, -200, 0)))
+        t = distance / cutoff
+        B.ipow(t, 4)
+        B.ineg(t)
+        B.iclip(t, -200, 0)
+        B.iexp(t)
+        B.imul(t, base_kernel)
+        return B.sum(t)
 
-    # Second normalization constant (narrower cutoff).
-    exp_cutoff2 = B.exp(B.clip(-(distance / cutoff_length2) ** 4, -200, 0))
-    smoothed = base_kernel * exp_cutoff2
-    del exp_cutoff2
-    norm_constant2 = B.sum(smoothed)
-    del smoothed
+    norm_constant1 = _smoothed_sum(cutoff_length)
+    norm_constant2 = _smoothed_sum(cutoff_length2)
 
     ratio_factor = ratio ** norm_ratio_exponent
     normalization_factor = (ratio_factor * norm_constant1 - norm_constant2) / (ratio_factor - 1)
 
-    # Final smoothing filter; reused once more for the correction below.
-    final_filter = B.exp(B.clip(-distance / 3.0, -200, 0))
-    filter_integral = B.sum(base_kernel * final_filter)
+    # Final smoothing filter: exp(clip(-distance/3, -200, 0)).
+    final_filter = distance / 3.0
+    B.ineg(final_filter)
+    B.iclip(final_filter, -200, 0)
+    B.iexp(final_filter)
 
+    smoothed = base_kernel * final_filter
+    filter_integral = B.sum(smoothed)
+    del smoothed
+
+    # corrected = base_kernel * (1 + correction_factor * final_filter)
     correction_factor = -normalization_factor / filter_integral
-    corrected_kernel = base_kernel * (1 + correction_factor * final_filter)
+    B.imul(final_filter, correction_factor)
+    B.iadd(final_filter, 1)
+    corrected_kernel = B.imul(final_filter, base_kernel)
     del final_filter, base_kernel
 
     if final_power is not None:
-        corrected_kernel = corrected_kernel ** final_power
+        B.ipow(corrected_kernel, final_power)
 
     return corrected_kernel
 
@@ -218,12 +230,18 @@ def create_kernel_LS2010(size, exponent, norm_ratio_exponent, causal=False, oute
                 term = axis.reshape(broadcast_shape) ** 2
                 dist_sq = term if dist_sq is None else dist_sq + term
                 del term
-            distance = B.sqrt(dist_sq)
+            distance = B.isqrt(dist_sq)
             del dist_sq
     else:
         if ndim == 1:
             raise ValueError("scale_metric is not supported for 1D kernels.")
         distance = scale_metric
+
+    # The coordinate arrays are only needed again for causal masking. In 1D
+    # the coordinate array is itself full-size, so release it now unless a
+    # causal mask will need it.
+    if not any(causal_tuple):
+        coord_arrays = None
 
     kernel = _apply_LS2010_correction(distance, exponent, norm_ratio_exponent, final_power)
 
@@ -241,7 +259,7 @@ def create_kernel_LS2010(size, exponent, norm_ratio_exponent, causal=False, oute
         mask_1d = (B.sign(coord) + 1) / 2
         broadcast_shape = [1] * ndim
         broadcast_shape[axis_idx] = coord.shape[0]
-        kernel = kernel * mask_1d.reshape(broadcast_shape)
+        kernel = B.imul(kernel, mask_1d.reshape(broadcast_shape))
 
     return kernel
 

--- a/tests/functional/test_backend_refactor_reference.py
+++ b/tests/functional/test_backend_refactor_reference.py
@@ -87,9 +87,11 @@ class TestSimulationNumpy:
     @pytest.fixture(autouse=True)
     def _setup_backend(self):
         prev = si.get_backend()
+        prev_precision = si.get_numerical_precision()
         si.set_backend('numpy')
         si.set_numerical_precision('float64')
         yield
+        si.set_numerical_precision(prev_precision)
         si.set_backend(prev)
 
     @pytest.mark.parametrize('case_name', SIM_CASES.keys())
@@ -113,9 +115,11 @@ class TestSimulationTorchCPU:
         if not _torch_available:
             pytest.skip("torch not available")
         prev = si.get_backend()
+        prev_precision = si.get_numerical_precision()
         si.set_backend('torch')
         si.set_numerical_precision('float64')
         yield
+        si.set_numerical_precision(prev_precision)
         si.set_backend(prev)
 
     @pytest.mark.parametrize('case_name', SIM_CASES.keys())
@@ -144,12 +148,14 @@ class TestSimulationTorchGPU:
         if not _torch_available or not torch.cuda.is_available():
             pytest.skip("CUDA not available")
         prev_backend = si.get_backend()
+        prev_precision = si.get_numerical_precision()
         si.set_backend('torch')
         si.set_numerical_precision('float64')
         if not hasattr(si, 'set_device'):
             pytest.skip("set_device not yet implemented")
         si.set_device('cuda')
         yield
+        si.set_numerical_precision(prev_precision)
         si.set_device('cpu')
         si.set_backend(prev_backend)
 
@@ -179,6 +185,7 @@ class TestAnalysisNumpyBackend:
     @pytest.fixture(autouse=True)
     def _setup(self, ref):
         prev = si.get_backend()
+        prev_precision = si.get_numerical_precision()
         si.set_backend('numpy')
         si.set_numerical_precision('float64')
         self.signal_1d = ref['np_sim_fbm_1d_circulant']
@@ -187,6 +194,7 @@ class TestAnalysisNumpyBackend:
         self.rtol = 1e-13
         self.atol = 1e-14
         yield
+        si.set_numerical_precision(prev_precision)
         si.set_backend(prev)
 
     def test_structure_function_order1(self, ref):
@@ -278,6 +286,7 @@ class TestAnalysisTorchBackend:
         if not _torch_available:
             pytest.skip("torch not available")
         prev = si.get_backend()
+        prev_precision = si.get_numerical_precision()
         si.set_backend('torch')
         si.set_numerical_precision('float64')
         self.signal_1d = ref['np_sim_fbm_1d_circulant']
@@ -286,6 +295,7 @@ class TestAnalysisTorchBackend:
         self.rtol = 1e-12
         self.atol = 1e-14
         yield
+        si.set_numerical_precision(prev_precision)
         si.set_backend(prev)
 
     def test_structure_function_order1(self, ref):
@@ -380,6 +390,7 @@ class TestAnalysisTorchGPU:
         if not hasattr(si, 'set_device'):
             pytest.skip("set_device not yet implemented")
         prev = si.get_backend()
+        prev_precision = si.get_numerical_precision()
         si.set_backend('torch')
         si.set_numerical_precision('float64')
         si.set_device('cuda')
@@ -389,6 +400,7 @@ class TestAnalysisTorchGPU:
         self.rtol = 1e-10
         self.atol = 1e-12
         yield
+        si.set_numerical_precision(prev_precision)
         si.set_device('cpu')
         si.set_backend(prev)
 

--- a/tests/functional/test_fft_offload.py
+++ b/tests/functional/test_fft_offload.py
@@ -1,0 +1,196 @@
+"""
+Tests for the chunked / out-of-core FFT engine (backend.set_fft_device).
+
+The chunked engine decomposes N-D FFTs into per-axis batched 1D FFTs
+streamed through the FFT device. Here the FFT device is 'cpu' with a tiny
+chunk size, which exercises exactly the same code paths as GPU offload
+(slab iteration, contiguity handling, write-back) minus the PCIe transfer.
+
+Chunked results are mathematically identical but not bit-identical to the
+direct transforms (per-axis ordering differs), so comparisons use small
+tolerances.
+"""
+
+import numpy as np
+import pytest
+
+import scaleinvariance as si
+from scaleinvariance import backend as B
+
+try:
+    import torch
+    _torch_available = True
+except ImportError:
+    _torch_available = False
+
+pytestmark = pytest.mark.skipif(not _torch_available, reason="torch not available")
+
+
+@pytest.fixture
+def torch_chunked():
+    """Torch backend with chunked FFTs forced (tiny chunks, cpu FFT device)."""
+    prev_backend = si.get_backend()
+    prev_precision = si.get_numerical_precision()
+    si.set_backend('torch')
+    si.set_numerical_precision('float64')
+    si.set_fft_device('cpu', chunk_bytes=256)  # tiny: many chunks even for small arrays
+    yield
+    si.set_fft_device(None)
+    si.set_numerical_precision(prev_precision)
+    si.set_backend(prev_backend)
+
+
+def _direct_and_chunked(fn, *args, **kwargs):
+    """Evaluate a backend FFT with offload disabled and enabled."""
+    si.set_fft_device(None)
+    direct = B.to_numpy(fn(*args, **kwargs))
+    si.set_fft_device('cpu', chunk_bytes=256)
+    chunked = B.to_numpy(fn(*args, **kwargs))
+    return direct, chunked
+
+
+SHAPES = [(8, 6), (5, 8), (7, 9), (4, 6, 10), (3, 5, 7)]
+
+
+class TestChunkedMatchesDirect:
+
+    @pytest.mark.parametrize('shape', SHAPES)
+    def test_rfftn(self, torch_chunked, shape):
+        rng = np.random.default_rng(1)
+        x = B.asarray(rng.standard_normal(shape))
+        direct, chunked = _direct_and_chunked(B.rfftn, x)
+        np.testing.assert_allclose(chunked, direct, rtol=1e-12, atol=1e-13)
+
+    @pytest.mark.parametrize('shape', SHAPES)
+    def test_irfftn_round_trip(self, torch_chunked, shape):
+        rng = np.random.default_rng(2)
+        x_np = rng.standard_normal(shape)
+        x = B.asarray(x_np)
+        spec = B.rfftn(x)
+        out = B.to_numpy(B.irfftn(spec, s=shape))
+        np.testing.assert_allclose(out, x_np, rtol=1e-12, atol=1e-13)
+
+    @pytest.mark.parametrize('shape', SHAPES)
+    def test_irfftn(self, torch_chunked, shape):
+        rng = np.random.default_rng(3)
+        spec_np = (rng.standard_normal(shape[:-1] + (shape[-1] // 2 + 1,))
+                   + 1j * rng.standard_normal(shape[:-1] + (shape[-1] // 2 + 1,)))
+        spec = B.asarray(spec_np)
+        direct, chunked = _direct_and_chunked(B.irfftn, spec, s=shape)
+        np.testing.assert_allclose(chunked, direct, rtol=1e-12, atol=1e-13)
+
+    @pytest.mark.parametrize('shape', SHAPES)
+    def test_fftn_ifftn(self, torch_chunked, shape):
+        rng = np.random.default_rng(4)
+        x_np = rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+        x = B.asarray(x_np)
+        direct, chunked = _direct_and_chunked(B.fftn, x)
+        np.testing.assert_allclose(chunked, direct, rtol=1e-12, atol=1e-13)
+        direct, chunked = _direct_and_chunked(B.ifftn, x)
+        np.testing.assert_allclose(chunked, direct, rtol=1e-12, atol=1e-13)
+
+    def test_float32(self, torch_chunked):
+        si.set_numerical_precision('float32')
+        rng = np.random.default_rng(5)
+        x = B.asarray(rng.standard_normal((16, 12)).astype(np.float32))
+        direct, chunked = _direct_and_chunked(B.rfftn, x)
+        np.testing.assert_allclose(chunked, direct, rtol=1e-5, atol=1e-6)
+
+    def test_1d_transforms_unaffected(self, torch_chunked):
+        """1D transforms never chunk; they must keep working with a device set."""
+        rng = np.random.default_rng(6)
+        x_np = rng.standard_normal(64)
+        x = B.asarray(x_np)
+        out = B.to_numpy(B.irfft(B.rfft(x), n=64))
+        np.testing.assert_allclose(out, x_np, rtol=1e-12, atol=1e-13)
+
+
+class TestChunkedSemantics:
+
+    def test_irfftn_does_not_mutate_input_by_default(self, torch_chunked):
+        rng = np.random.default_rng(7)
+        spec_np = (rng.standard_normal((6, 5)) + 1j * rng.standard_normal((6, 5)))
+        spec = B.asarray(spec_np)
+        before = B.to_numpy(spec).copy()
+        B.irfftn(spec, s=(6, 8))
+        np.testing.assert_array_equal(B.to_numpy(spec), before)
+
+    def test_irfftn_cropped_raises_with_offload(self, torch_chunked):
+        spec = B.asarray(np.ones((8, 5), dtype=np.complex128))
+        with pytest.raises(ValueError, match="Chunked irfftn"):
+            B.irfftn(spec, s=(4, 8))  # cropped: spectrum rows != s[0]
+
+    def test_invalid_chunk_bytes(self, torch_chunked):
+        with pytest.raises(ValueError):
+            si.set_fft_device('cpu', chunk_bytes=0)
+
+    def test_get_fft_device(self, torch_chunked):
+        assert si.get_fft_device() == 'cpu'
+        si.set_fft_device(None)
+        assert si.get_fft_device() is None
+
+    def test_numpy_backend_unaffected(self):
+        prev_backend = si.get_backend()
+        try:
+            si.set_backend('numpy')
+            si.set_fft_device('cpu', chunk_bytes=256)
+            rng = np.random.default_rng(8)
+            x = rng.standard_normal((8, 6))
+            out = B.irfftn(B.rfftn(x), s=(8, 6))
+            np.testing.assert_allclose(out, x, rtol=1e-12, atol=1e-13)
+        finally:
+            si.set_fft_device(None)
+            si.set_backend(prev_backend)
+
+
+class TestSimulationsWithOffload:
+    """Full simulations with chunked FFTs must match the direct results."""
+
+    def test_fif_nd_matches_direct(self, torch_chunked):
+        torch.manual_seed(123)
+        si.set_fft_device(None)
+        direct = si.FIF_ND((32, 32), alpha=1.8, C1=0.1, H=0.3, periodic=False)
+        torch.manual_seed(123)
+        si.set_fft_device('cpu', chunk_bytes=256)
+        chunked = si.FIF_ND((32, 32), alpha=1.8, C1=0.1, H=0.3, periodic=False)
+        np.testing.assert_allclose(chunked, direct, rtol=1e-10, atol=1e-12)
+
+    def test_fif_nd_odd_axes_matches_direct(self, torch_chunked):
+        torch.manual_seed(321)
+        si.set_fft_device(None)
+        direct = si.FIF_ND((16, 16), alpha=1.8, C1=0.1, H=0.3, periodic=True,
+                           observable_kernel_odd_axes=(True, False))
+        torch.manual_seed(321)
+        si.set_fft_device('cpu', chunk_bytes=256)
+        chunked = si.FIF_ND((16, 16), alpha=1.8, C1=0.1, H=0.3, periodic=True,
+                            observable_kernel_odd_axes=(True, False))
+        np.testing.assert_allclose(chunked, direct, rtol=1e-10, atol=1e-12)
+
+    def test_fif_nd_ls2010_observable_matches_direct(self, torch_chunked):
+        torch.manual_seed(99)
+        si.set_fft_device(None)
+        direct = si.FIF_ND((16, 16), alpha=1.7, C1=0.05, H=0.2, periodic=True,
+                           kernel_construction_method_observable='LS2010')
+        torch.manual_seed(99)
+        si.set_fft_device('cpu', chunk_bytes=256)
+        chunked = si.FIF_ND((16, 16), alpha=1.7, C1=0.05, H=0.2, periodic=True,
+                            kernel_construction_method_observable='LS2010')
+        np.testing.assert_allclose(chunked, direct, rtol=1e-10, atol=1e-12)
+
+    def test_fbm_nd_matches_direct(self, torch_chunked):
+        torch.manual_seed(7)
+        si.set_fft_device(None)
+        direct = si.fBm_ND_circulant((16, 32), H=0.4, periodic=True)
+        torch.manual_seed(7)
+        si.set_fft_device('cpu', chunk_bytes=256)
+        chunked = si.fBm_ND_circulant((16, 32), H=0.4, periodic=True)
+        np.testing.assert_allclose(chunked, direct, rtol=1e-10, atol=1e-12)
+
+    def test_fif_3d_matches_direct(self, torch_chunked):
+        torch.manual_seed(11)
+        si.set_fft_device(None)
+        direct = si.FIF_ND((8, 8, 8), alpha=1.8, C1=0.1, H=0.3, periodic=True)
+        torch.manual_seed(11)
+        si.set_fft_device('cpu', chunk_bytes=256)
+        chunked = si.FIF_ND((8, 8, 8), alpha=1.8, C1=0.1, H=0.3, periodic=True)
+        np.testing.assert_allclose(chunked, direct, rtol=1e-10, atol=1e-12)


### PR DESCRIPTION
## Summary

This PR adds support for out-of-core N-D FFTs via GPU offload and introduces a suite of in-place operations to reduce peak memory usage in simulations. The changes enable simulations larger than GPU VRAM by streaming FFT chunks through the GPU while keeping arrays in host RAM, and optimize the FIF pipeline to bound memory allocation.

## Key Changes

### Out-of-Core FFT Engine
- **New API**: `set_fft_device(device, chunk_bytes)` and `get_fft_device()` enable chunked FFT offload to a separate device (typically GPU)
- **Implementation**: Decompose N-D FFTs into per-axis batched 1D transforms streamed through the FFT device in bounded chunks
- **Scope**: Only full N-D transforms (`ndim >= 2`, all axes) are chunked; 1D and axis-subset transforms run directly
- **Semantics**: Results are mathematically identical but not bit-identical to direct transforms (per-axis evaluation order differs)
- **Torch-only**: Requires PyTorch backend; NumPy backend unaffected
- **New functions**: `_fft_offload_active()`, `_chunked_fft_axis_()`, `_chunked_rfftn()`, `_chunked_irfftn()`, `_chunked_cfftn()`

### In-Place Operations
- **New API**: `imul()`, `iadd()`, `isub()`, `idiv()`, `ipow()`, `ineg()`, `iexp()`, `icos()`, `isin()`, `isqrt()`, `iclip()`, `imaximum()`
- **Purpose**: Mutate first argument in-place and return it, avoiding full-size buffer allocations
- **Semantics**: Bit-identical results to out-of-place equivalents; only pass arrays you own
- **Backend support**: Both NumPy and Torch backends

### FIF Pipeline Optimization
- **Memory bounds**: Refactored `FIF_1D()` and `FIF_ND()` to use in-place operations and eager buffer release
- **Kernel handling**: Move kernels to Fourier space before noise generation to avoid coexistence
- **Spectral path**: Inline `fractional_integral_spectral()` calls with explicit buffer management
- **Convolution**: Use in-place multiplication in `periodic_convolve()` and `periodic_convolve_nd()`
- **Lévy noise**: Optimized `_extremal_levy_core()` to use in-place ops, reducing peak allocation from ~7 to 3 full-size buffers

### Kernel Building
- **Extracted**: `_build_riesz_kernel()` from `fractional_integral_spectral()` for reuse in FIF pipeline
- **In-place**: Uses in-place operations throughout for memory efficiency
- **Odd axes**: Handles complex kernels for odd-axis transforms

### Other Improvements
- **RNG optimization**: `exponential()` now uses `Tensor.exponential_()` directly instead of `Exponential(rate).sample()`, avoiding extra allocations
- **Frequency computation**: `_isotropic_rfft_frequencies()` uses `isqrt()` for in-place square root
- **Kernel correction**: `_apply_LS2010_correction()` and `_apply_outer_scale()` refactored with in-place chains
- **API enhancement**: `irfftn()` gains `overwrite_input` parameter to permit spectrum reuse as scratch in chunked path

### Testing
- **New test file**: `tests/functional/test_fft_offload.py` with 196 lines of comprehensive tests
- **Coverage**: Chunked FFT correctness, semantics, full simulations (FIF_ND, fBm_ND, 3D), precision handling, edge cases
- **Validation**: Ensures chunked results match direct transforms within FFT round-off tolerance

## Notable Implementation Details

- Chunked FFTs iterate over slabs along a non-transform axis to keep each transferred block complete
- `_chunk_rows()` computes how many

https://claude.ai/code/session_01DdRRcgzmNUyW1JJ7Wq228J